### PR TITLE
[Story] 식단 목록 조회 — 날짜별 그룹핑 + 컬러 배지

### DIFF
--- a/src/app/api/meals/route.ts
+++ b/src/app/api/meals/route.ts
@@ -3,6 +3,14 @@ import { prisma } from "@/lib/prisma";
 
 const VALID_MEAL_TYPES = ["아침", "점심", "저녁", "간식"];
 
+export async function GET() {
+  const meals = await prisma.meal.findMany({
+    orderBy: [{ date: "desc" }, { mealType: "asc" }],
+  });
+
+  return NextResponse.json(meals);
+}
+
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();


### PR DESCRIPTION
## Summary
- `GET /api/meals` API Route 추가
- `/meals` 페이지: 날짜별 그룹핑, 한국어 날짜 포맷, 끼니별 컬러 배지
- 빈 상태 시 "기록된 식단이 없습니다" + 링크

Closes #9

---
_Part of autopilot session #6_